### PR TITLE
Add chemiscope plot new frames example

### DIFF
--- a/python/examples/reciprocal_lattice_examples.ipynb
+++ b/python/examples/reciprocal_lattice_examples.ipynb
@@ -775,6 +775,14 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "8bc51cc6",
+   "metadata": {},
+   "source": [
+    "## 4.1 Update chemiscope visualizer parameters"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "id": "7e4df2b7",
@@ -806,31 +814,11 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "a9882331",
+   "cell_type": "markdown",
+   "id": "c9bf158c",
    "metadata": {},
-   "outputs": [],
    "source": [
-    "import chemiscope\n",
-    "import ase.lattice\n",
-    "fcc_al = ase.lattice.cubic.FaceCenteredCubic('Al')\n",
-    "\n",
-    "cutoff_parameters_box = ParametersBox(cutoff = (3., 0.1, 10., 0.1, r'$r_c / Å$'))\n",
-    "fcc_al_widget = chemiscope.show(frames = [fcc_al], mode=\"structure\", \n",
-    "                        environments=chemiscope.all_atomic_environments(fcc_al),\n",
-    "                        settings={\"structure\":[{\"unitCell\":True,\"supercell\":{\"0\":3,\"1\":3,\"2\":3}}]}\n",
-    "                        )"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "b2800fcc",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "print(dir(fcc_al_widget))"
+    "## 4.2 Update chemiscope visualizer atomic structure"
    ]
   },
   {
@@ -840,12 +828,41 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "def chemiscope_update_visualizers(cutoff, visualizers=None):\n",
-    "    chemiscope_widget = visualizers[0]\n",
+    "example4p2_code_input = WidgetCodeInput(\n",
+    "        function_name=\"return_structure\", \n",
+    "        function_parameters=\"\",\n",
+    "        docstring=\"\"\"\n",
+    "Return structure of interest to visualize\n",
+    "\n",
+    ":return: atomic structure visualizable by chemiscope (ase.Atoms)\n",
+    "\"\"\",\n",
+    "        function_body=\"\"\"\n",
+    "import ase.lattice\n",
+    "fcc_al = ase.lattice.cubic.FaceCenteredCubic('Al')\n",
+    "return fcc_al\n",
+    "\"\"\"\n",
+    ")\n",
+    "\n",
+    "def chemiscope_update_visualizers_structure(code_input, visualizers):\n",
+    "    cleared_output = visualizers[0]\n",
     "    frame = code_input.get_function_object()()\n",
-    "    cs = chemiscope.show(frames=[frame])\n",
-    "    display(cs)\n",
-    "    \n"
+    "    with cleared_output:\n",
+    "        chemiscope_widget = chemiscope.show(frames = [frame], mode=\"structure\")\n",
+    "        display(chemiscope_widget)\n",
+    "\n",
+    "\n",
+    "    \n",
+    "\n",
+    "example4p2_code_demo = CodeDemo(\n",
+    "            code_input=example4p2_code_input,\n",
+    "            input_parameters_box=None,\n",
+    "            visualizers=[ClearedOutput()],\n",
+    "            update_visualizers=chemiscope_update_visualizers_structure,\n",
+    "            code_checker=None,\n",
+    "            update_on_input_parameter_change=False\n",
+    ")\n",
+    "\n",
+    "display(example4p2_code_demo)"
    ]
   }
  ],

--- a/python/scwidgets/_code_demo.py
+++ b/python/scwidgets/_code_demo.py
@@ -87,8 +87,9 @@ class CodeDemo(VBox, Answer):
 
         if (update_on_input_parameter_change) and (input_parameters_box is None):
             warnings.warn(
-                "`update_on_input_parameter_change` is True, but `input_parameters_box` is None. `update_on_input_parameter_change` does not affect anything without a `input_parameters_box`"
+                "update_on_input_parameter_change is True, but input_parameters_box is None. update_on_input_parameter_change does not affect anything without a input_parameters_box. Setting update_on_input_parameter_change to False"
             )
+            self._update_on_input_parameter_change = False
         # TODO should this be mentioned to the user?
         # if len(self._visualizers) == 0 and self._update_visualizers is not None:
         #    warnings.warn("self._update_visualizers is given without visualizers.")


### PR DESCRIPTION
Added example using a CleardOutput to update the visualized frame.

**Discussion point: Wrap the update_visualizers with a ClearedOutput so we don't have to do this for all displayed object**
The problem however is that objects like PyplotOutput works with updates. So the figure is only one time displayed and then only updated. If we cleared the outputs of the update_visualizers by default, we would need to redisplay figures or implement an exception for this kind of visualizers which would be complicated. The updating of figures is useful without redisplaying it, since it allows a more visually smooth experience. So I did not do this
