### PR TITLE
reload button mockup and visual cues on saving

### DIFF
--- a/python/scwidgets/_answer.py
+++ b/python/scwidgets/_answer.py
@@ -47,9 +47,11 @@ class Answer:
             self._save_button.description = 'Saved!'
             self._reload_answer_button.disabled = True
         if save_status == AnswerStatus.NOT_SAVED:
+            self._save_button.description = 'Save answer'
             self._save_button.disabled = False
             self._save_button.button_style = ''
             self._reload_answer_button.disabled = False
+            self._save_output.clear_output()
     @property
     def answer_value(self):
         raise NotImplementedError("answer_value property has not been implemented.")
@@ -68,11 +70,26 @@ class Answer:
         self._reload_answer_button = Button(description="Reload saved answer", layout=Layout(width="200px", height="100%"),disabled = True)
         self._on_save_callback = callback
         self._save_button.on_click(self._on_save_callback)
-        self._reload_answer_button.on_click(self.on_reload_callback)
+        self._reload_answer_button.on_click(self._request_reload_confirmation)
         return VBox([VBox([self._save_button,self._reload_answer_button]), self._save_output],
                 layout=Layout(align_items="flex-start")
         )
-
+    def _request_reload_confirmation(self,change=""):
+        def collapse_after_confirmation(callback=None,change=""):
+            if callback != None:
+                callback()
+                self._save_output.clear_output()
+            else :
+                self._save_output.clear_output()
+        confirm_button = Button(description="Yes")
+        cancel_button = Button(description="Cancel")
+        confirm_button.on_click(lambda _: collapse_after_confirmation(self.on_reload_callback))
+        cancel_button.on_click(lambda _: collapse_after_confirmation())
+        with self._save_output:
+            self._save_output.clear_output()
+            print("Are you sure ? This will reload irreversibly your last saved answer.")
+            with self._save_output:
+                display(HBox([confirm_button,cancel_button]))
     def _update_save_widget(self, callback):
         if self._save_button is not None and self._on_save_callback is not None:
             self._save_button.on_click(self._on_save_callback, remove=True)
@@ -128,6 +145,8 @@ class AnswerRegistry(VBox):
         self._answer_widgets = {}
         self._preoutput = Output(layout=Layout(width='99%', height='99%'))
         self._output = Output(layout=Layout(width='99%', height='99%'))
+        self._save_all_button = Button(description = 'Save all answers')
+        self._save_all_button.on_click(self._request_confirmation)
         super().__init__(
                 [self._preoutput, self._savebox, self._output])
 
@@ -153,7 +172,6 @@ class AnswerRegistry(VBox):
                 self._savebox.children = [self._dropdown, self._load_answers_button]
         self._current_dropdown_value = change['new']
 
-
     def _load_answers(self, change=""):
         """
         loads registry when _load_answers_button is clicked
@@ -174,7 +192,7 @@ class AnswerRegistry(VBox):
                     self._answer_widgets[answer_key]._cached_value = answer_value
         if not error_occured:
             self._disable_savebox()
-            self.children = [self._savebox, self._reload_button, self._output]
+            self.children = [self._savebox, HBox([self._reload_button, self._save_all_button]), self._output]
             with self._output:
                 print(f"\033[92m File '{self._answers_filename}' loaded successfully.")
 
@@ -222,7 +240,7 @@ class AnswerRegistry(VBox):
             self._disable_savebox()
             self._json_list = list(dict.fromkeys([self._answers_filename] + self._json_list))
             self._dropdown.options = self._json_list
-            self.children = [self._savebox, self._reload_button, self._output]
+            self.children = [self._savebox,  HBox([self._reload_button, self._save_all_button]), self._output]
             self.clear_output()
             with self._output:
                 print(f"\033[92m File {self._answers_filename} successfully created and loaded.")
@@ -248,6 +266,29 @@ class AnswerRegistry(VBox):
                 print(f"The answer was successfully recorded in '{self._answers_filename}'")
             return True
 
+    def _request_confirmation(self,change=""):
+        def collapse_after_confirmation(callback=None,change=""):
+            if callback != None:
+                callback()
+                self.clear_output()
+                self._save_all_button.button_style = 'success'
+                self._save_all_button.description = 'Saved!'
+                with self._output : 
+                    print(f"All answers were successfully recorded in '{self._answers_filename}'")
+            else :
+                self.clear_output()
+            self.children = [self._savebox, HBox([self._reload_button, self._save_all_button]), self._output]
+        confirm_button = Button(description="Yes")
+        cancel_button = Button(description="Cancel")
+        confirm_button.on_click(lambda _: collapse_after_confirmation(self._save_all))
+        cancel_button.on_click(lambda _: collapse_after_confirmation())
+        with self._output:
+            self.clear_output()
+            print("Are you sure ? This will modify irreversibly your answer file.")
+            self.children = [self._savebox, HBox([self._reload_button, self._save_all_button]), HBox([self._output, confirm_button,cancel_button])]        
+    def _save_all(self,change=None):
+        for answer_key, widgets in self._answer_widgets.items():
+            widgets._save_button.click()
     @staticmethod
     def is_name_empty(name):
         return len(name) == name.count(" ")

--- a/python/scwidgets/_answer.py
+++ b/python/scwidgets/_answer.py
@@ -36,22 +36,25 @@ class Answer:
        self.save_status = AnswerStatus.SAVED
     def set_status_not_saved(self, change=None):
        self.save_status = AnswerStatus.NOT_SAVED
+
     @property
     def save_status(self):
         return self._save_status if hasattr(self, "_save_status") else None
     @save_status.setter
+
     def save_status(self, save_status):
         if save_status == AnswerStatus.SAVED:
             self._save_button.disabled = True
-            self._save_button.button_style = 'success'
-            self._save_button.description = 'Saved!'
+            self._save_button.button_style = ''
+            self._save_button.description = 'Answer saved'
             self._reload_answer_button.disabled = True
         if save_status == AnswerStatus.NOT_SAVED:
             self._save_button.description = 'Save answer'
             self._save_button.disabled = False
-            self._save_button.button_style = ''
+            self._save_button.button_style = 'warning'
             self._reload_answer_button.disabled = False
             self._save_output.clear_output()
+
     @property
     def answer_value(self):
         raise NotImplementedError("answer_value property has not been implemented.")
@@ -62,9 +65,11 @@ class Answer:
 
     def on_save(self):
         raise NotImplementedError("on_save has not been implemented.")
+
     def on_reload_callback(self,change=None):
         self.answer_value = self._cached_value
         self.save_status = AnswerStatus.SAVED 
+
     def _init_save_widget(self, callback):
         self._save_button = Button(description="Save answer", layout=Layout(width="200px", height="100%"))
         self._reload_answer_button = Button(description="Reload saved answer", layout=Layout(width="200px", height="100%"),disabled = True)
@@ -74,6 +79,7 @@ class Answer:
         return VBox([VBox([self._save_button,self._reload_answer_button]), self._save_output],
                 layout=Layout(align_items="flex-start")
         )
+
     def _request_reload_confirmation(self,change=""):
         def collapse_after_confirmation(callback=None,change=""):
             if callback != None:
@@ -90,6 +96,7 @@ class Answer:
             print("Are you sure ? This will reload irreversibly your last saved answer.")
             with self._save_output:
                 display(HBox([confirm_button,cancel_button]))
+
     def _update_save_widget(self, callback):
         if self._save_button is not None and self._on_save_callback is not None:
             self._save_button.on_click(self._on_save_callback, remove=True)
@@ -158,6 +165,7 @@ class AnswerRegistry(VBox):
 
         with self._preoutput:
             print("Please choose a save file and confirm before answering questions.")
+
     def clear_output(self):
         self._output.clear_output()
 
@@ -271,8 +279,6 @@ class AnswerRegistry(VBox):
             if callback != None:
                 callback()
                 self.clear_output()
-                self._save_all_button.button_style = 'success'
-                self._save_all_button.description = 'Saved!'
                 with self._output : 
                     print(f"All answers were successfully recorded in '{self._answers_filename}'")
             else :
@@ -286,9 +292,11 @@ class AnswerRegistry(VBox):
             self.clear_output()
             print("Are you sure ? This will modify irreversibly your answer file.")
             self.children = [self._savebox, HBox([self._reload_button, self._save_all_button]), HBox([self._output, confirm_button,cancel_button])]        
+
     def _save_all(self,change=None):
         for answer_key, widgets in self._answer_widgets.items():
             widgets._save_button.click()
+
     @staticmethod
     def is_name_empty(name):
         return len(name) == name.count(" ")

--- a/python/scwidgets/_answer.py
+++ b/python/scwidgets/_answer.py
@@ -69,13 +69,13 @@ class Answer:
     def save_status(self, save_status):
         if save_status == AnswerStatus.SAVED:
             self._save_button.disabled = True
-            self._save_button.button_style = ''
+            self._save_button.remove_class("answer-not-saved")
             self._save_button.description = 'Answer saved'
             self._reload_answer_button.disabled = True
         if save_status == AnswerStatus.NOT_SAVED:
             self._save_button.description = 'Save answer'
             self._save_button.disabled = False
-            self._save_button.button_style = 'warning'
+            self._save_button.add_class("answer-not-saved")
             self._reload_answer_button.disabled = False
             self._save_output.clear_output()
 

--- a/python/scwidgets/_code_demo.py
+++ b/python/scwidgets/_code_demo.py
@@ -287,7 +287,7 @@ class CodeDemo(VBox, Answer):
         self._save_button = None
         self._on_save_callback = None
         self._save_output = None
-
+        self._code_input.observe(self.set_status_not_saved,"function_body")
         # TODO should this be mentioned to the user?
         # if len(self._visualizers) == 0 and self._update_visualizers is not None:
         #    warnings.warn("self._update_visualizers is given without visualizers.")
@@ -610,7 +610,9 @@ class CodeDemo(VBox, Answer):
         if self._save_button is None and self._on_save_callback is None:
             self._init_save_widget(callback)
             self._save_output = self._error_output
-            save_widget = HBox([VBox([self._save_button],
+            #@Joao I believe this is doubled code with respect to _answer.py _init_save_widget(), 
+            # we should be able to just call save_widget = self._init_save_widget(callback)
+            save_widget = HBox([VBox([VBox([self._save_button,self._reload_answer_button])],
                         layout = Layout(display='flex',
                         flex_flow='column',
                         align_items='flex-end',

--- a/python/scwidgets/_code_demo.py
+++ b/python/scwidgets/_code_demo.py
@@ -133,8 +133,10 @@ class CodeDemoButton(ipywidgets.Button):
                 self.remove_class("scwidget-button--unchecked")
             elif status == CodeDemoStatus.CHECKED:
                 self.disabled = True
+                self.description = "Checked!"
                 self.remove_class("scwidget-button--unchecked")
             elif status == CodeDemoStatus.UNCHECKED:
+                self.description = "Check code"
                 self.disabled = False
                 self.add_class("scwidget-button--unchecked")
             elif status == CodeDemoStatus.UPDATING or status == CodeDemoStatus.UP_TO_DATE or status == CodeDemoStatus.OUT_OF_DATE:
@@ -287,7 +289,8 @@ class CodeDemo(VBox, Answer):
         self._save_button = None
         self._on_save_callback = None
         self._save_output = None
-        self._code_input.observe(self.set_status_not_saved,"function_body")
+        if self._code_input != None:
+            self._code_input.observe(self.set_status_not_saved,"function_body")
         # TODO should this be mentioned to the user?
         # if len(self._visualizers) == 0 and self._update_visualizers is not None:
         #    warnings.warn("self._update_visualizers is given without visualizers.")

--- a/python/scwidgets/scwidget_style.css
+++ b/python/scwidgets/scwidget_style.css
@@ -26,6 +26,10 @@
     border-color: #20b5e9;
     background-color: #20b5e9;
 }
+.answer-not-saved{
+    border-color: #c0abe5;
+    background-color: #c0abe5;
+}
 .scwidget-visualizer{
     opacity: 1.0;
 }

--- a/python/scwidgets/scwidget_style.css
+++ b/python/scwidgets/scwidget_style.css
@@ -5,9 +5,11 @@
     height: auto;
 }
 .scwidget-button--out-of-date{
+    background-color: #e95420;
     border-color: #e95420;
 }
 .scwidget-button--unchecked{
+    background-color: #20b5e9;
     border-color: #20b5e9;
 }
 


### PR DESCRIPTION
Implementation of a reload button for answer (to recover saved version of an answer after bad changes) and visual cues for saving functionality.
Points to discuss:
- Visual cues on saving : css options for the saving button and the implementation. As a default, the visual cue is the 'success' style from ipywidgets. In terms of implementation, I tried to mimic ```CodeDemoStatus```for the much smaller saving button, let me know if its overkill or not clear enough. 
- Reload button : when I implemented the button, I realised that it is a potential risk for students if they reload an (empty) answer before saving. The reload button does not interact with the json file, so the effect has small range, but still important to discuss. I feel that if the button is validated and stays in the library, it should be moved as far away as possible from the save button, in order to avoid miss clicks. Other points to discuss are the button text, implementation (normally encapsulated in ```Answer``` and ```AnswerRegistry```)

An example : 

https://user-images.githubusercontent.com/98404937/205985206-fbee3cbe-c08a-4017-b091-bc65b3b549d2.mp4