### PR TITLE
Added a reload all answers button, fixed TypeAssert, continuation of ParametersBox as Answer

### DIFF
--- a/python/scwidgets/_answer.py
+++ b/python/scwidgets/_answer.py
@@ -146,6 +146,7 @@ class AnswerRegistry(VBox):
         self._load_answers_button = Button(description='Confirm')
         self._create_savefile_button = Button(description='Confirm')
         self._reload_button = Button(description='Choose other file')
+        self._reload_all_answers_button = Button(description='Reload all answers',tooltip="Reload answers saved in .json file to notebook.")
         self._new_savefile = HBox([self._student_name_text, self._create_savefile_button])
         self._dropdown = Dropdown(
                             options=self._json_list,
@@ -161,7 +162,6 @@ class AnswerRegistry(VBox):
         self._preoutput = Output(layout=Layout(width='99%', height='99%'))
         self._output = Output(layout=Layout(width='99%', height='99%'))
         self._save_all_button = Button(description = 'Save all answers')
-        self._save_all_button.on_click(lambda _ : request_confirmation(self._output,self._save_all))
         super().__init__(
                 [self._preoutput, self._savebox, self._output])
 
@@ -170,7 +170,8 @@ class AnswerRegistry(VBox):
         self._create_savefile_button.on_click(self._create_savefile)
         self._dropdown.observe(self._on_choice,names='value')
         self._reload_button.on_click(self._enable_savebox)
-
+        self._save_all_button.on_click(lambda _ : request_confirmation(self._output,self._save_all))
+        self._reload_all_answers_button.on_click(lambda _ : request_confirmation(self._output,self._load_all))
         with self._preoutput:
             print("Please choose a save file and confirm before answering questions.")
 
@@ -219,7 +220,7 @@ class AnswerRegistry(VBox):
 
         if not error_occured:
             self._disable_savebox()
-            self.children = [self._savebox, HBox([self._reload_button, self._save_all_button]), self._output]
+            self.children = [self._savebox, HBox([self._reload_button, self._save_all_button,self._reload_all_answers_button]), self._output]
             with self._output:
                 print(f"\033[92m File '{self._answers_filename}' loaded successfully.")
 

--- a/python/scwidgets/_check_registry.py
+++ b/python/scwidgets/_check_registry.py
@@ -130,13 +130,13 @@ class Check:
             output = self._widget.compute_output(**self._inputs_parameters[i])
 
             if self._fingerprint is None:
-                numeric = [int, float, np.floating ]
-                if not(isinstance(output, type(self._reference_outputs[i]))):
-                    # Type mismatches between built-in (except complex) and numpy numeric types should be ignored.
-                    if not type(output) in numeric:
-                        print(f"TypeAssert failed: Expected type {type(self._reference_outputs[i])} but got {type(output)}.")
-                        return False
-                elif hasattr(self._reference_outputs[i], "shape") and (output.shape != self._reference_outputs[i].shape):
+                #numeric = [int, float, np.floating ]
+                #if not(isinstance(output, type(self._reference_outputs[i]))):
+                #    # Type mismatches between built-in (except complex) and numpy numeric types should be ignored.
+                #    if not type(output) in numeric:
+                #        print(f"TypeAssert failed: Expected type {type(self._reference_outputs[i])} but got {type(output)}.")
+                #        return False
+                if hasattr(self._reference_outputs[i], "shape") and (output.shape != self._reference_outputs[i].shape):
                     print(f"ShapeAssert failed: Expected shape {self._reference_outputs[i].shape} but got {output.shape}.")
                     return False
                 elif hasattr(self._reference_outputs[i], "__len__") and (len(output) != len(self._reference_outputs[i])):

--- a/python/scwidgets/_check_registry.py
+++ b/python/scwidgets/_check_registry.py
@@ -1,6 +1,6 @@
 import functools
 import ipywidgets
-
+import numpy as np
 
 class CheckRegistry:
     def __init__(self):
@@ -130,9 +130,12 @@ class Check:
             output = self._widget.compute_output(**self._inputs_parameters[i])
 
             if self._fingerprint is None:
+                numeric = [int, float, np.floating ]
                 if not(isinstance(output, type(self._reference_outputs[i]))):
-                    print(f"TypeAssert failed: Expected type {type(self._reference_outputs[i])} but got {type(output)}.")
-                    return False
+                    # Type mismatches between built-in (except complex) and numpy numeric types should be ignored.
+                    if not type(output) in numeric:
+                        print(f"TypeAssert failed: Expected type {type(self._reference_outputs[i])} but got {type(output)}.")
+                        return False
                 elif hasattr(self._reference_outputs[i], "shape") and (output.shape != self._reference_outputs[i].shape):
                     print(f"ShapeAssert failed: Expected shape {self._reference_outputs[i].shape} but got {output.shape}.")
                     return False

--- a/python/scwidgets/_code_demo.py
+++ b/python/scwidgets/_code_demo.py
@@ -528,32 +528,20 @@ class CodeDemo(VBox, Answer):
     def has_update_button(self):
         # used to determine if update button has to be initialized
         # to cover the cases where no code input is used
-        no_code_input_demo = (
-            (len(self._visualizers) > 0)
-            and (self._input_parameters_box is not None)
-            and (self._input_parameters_box.refresh_mode == "click")
-        )
-        with_code_input_demo = (
-            len(self._visualizers) > 0 and self._code_input is not None
-        )
-        return (no_code_input_demo or with_code_input_demo)
+        return self.has_update_functionality() and (
+             self._code_input is not None or self._input_parameters_box is None 
+             or self._input_parameters_box.refresh_mode == "click"
+         )
 
     def has_update_functionality(self):
-        # to cover the cases where no code input is used
-        no_code_input_demo = (
-            (len(self._visualizers) > 0)
-            and (self._input_parameters_box is not None)
-        )
-        with_code_input_demo = (
-            len(self._visualizers) > 0 and self._code_input is not None
-        )
-        return no_code_input_demo or with_code_input_demo
+        # if there are visualizers, there is something that must be updated
+         return len(self._visualizers) > 0
 
     def has_check_functionality(self):
-        return self.has_check_button()
+        return self._check_registry is not None
 
     def has_check_button(self):
-        return self._check_registry is not None
+        return self.has_check_functionality()
 
     def check_and_update(self, change=None):
         self.check(change)
@@ -694,6 +682,9 @@ class CodeDemo(VBox, Answer):
         if self.has_update_functionality():
             self.set_update_status(CodeDemoStatus.UP_TO_DATE)
 
+         # If there is nothing to update for changes, always leave the button clickable
+        if self.has_update_button() and self._code_input is None and self._input_parameters_box is None:
+            self.update_button.set_status(CodeDemoStatus.OUT_OF_DATE)
     def compute_output(self, *args, **kwargs):
         # TODO remove function within function
         # For checking we ignore

--- a/python/setup.cfg
+++ b/python/setup.cfg
@@ -10,9 +10,10 @@ include_package_data = True
 zip_safe = True
 packages = find:
 install_requires = numpy
-                   widget_code_input == 3.1
-#                   widget_code_input >= 3.5.0 # first needs fix of issue https://github.com/jupyter-widgets/widget-ts-cookiecutter/issues/120
+                   widget_code_input >= 3.5.0 # == if need to install in Noto
+                   jupyterlab-widgets >= 3.0.5
+                   widgetsnbextension >=4.0.5
                    matplotlib
-                   ipywidgets >= 8.0.0
+                   ipywidgets >= 8.0.4
                    traitlets
                    ipympl


### PR DESCRIPTION

This PR implements:

* “Reload all answers button” side to the “Save all answers button” in AnswerRegistry
<img width="516" alt="image" src="https://user-images.githubusercontent.com/98404937/210181662-980734a3-ad83-42bb-bb52-9b45427c8d79.png">


* TypeAssert fix : all built-in and numpy numeric types are equivalently.  Before this fix, TypeAssert raises if expected output is ‘float’ and student output is ‘numpy.float64’ or ‘int’, for example.
* Following Michele code, a first ‘complete’ implementation of ParametersBox as an Answer (with visual cues, without a text output for successful answer)
<img width="909" alt="image" src="https://user-images.githubusercontent.com/98404937/210181633-232a1b8a-dae1-460c-a7b2-d4e783892150.png">

    * When I was implementing this I noticed that some ParametersBox logic was still in CodeDemo, just want to check if there is a special reason for this part of the code to be there and not in the ParametersBox class